### PR TITLE
Add basic CLI format converter using built-in translators

### DIFF
--- a/aotpy/converter.py
+++ b/aotpy/converter.py
@@ -1,0 +1,56 @@
+"""
+Entrypoint for CLI utility for converting other telemetry formats to AOT format files.
+"""
+
+import argparse
+
+from .translators import get_available_translators
+
+
+# TODO: Define type for available_translators
+def make_parser(available_translators: dict) -> argparse.ArgumentParser:
+    """Constructs an argparser for CLI converter utility updated with the available translators."""
+    parser = argparse.ArgumentParser(
+        prog='AOT Converter',
+        description="Convert telemetry files to AOT format.",
+        epilog="")
+
+    parser.add_argument("-o", "--out", type=str, default="out.aot", help="output file name/path")
+
+    subparsers = parser.add_subparsers(help="available translators", dest="system")
+    for system_name, system_info in available_translators.items():
+        system_parser = subparsers.add_parser(system_name)
+        for param in system_info["params"]:
+            system_parser.add_argument(f"--{param.name}", type=param.type, metavar=param.type.__name__.upper(), required=True)
+
+    return parser
+
+
+def main() -> None:
+    available_translators = get_available_translators()
+
+    # Create argparser
+    parser = make_parser(available_translators)
+    args = parser.parse_args()
+
+    if args.system is None:
+        parser.print_help()
+        return
+
+    # Retrieve desired system name and check if translator is vailable
+    system_name = args.system.strip().lower()
+    if system_name not in available_translators:
+        raise ValueError(f"Translator for system \'{system_name}\' not available.")
+
+    # Parse additional parameters for translator initialization
+    required_params = [param.name for param in available_translators.get(system_name).get("params")]
+    system_params = {param_name: param_value for param_name, param_value in vars(args).items() if
+                     param_name in required_params}
+
+    # Create system object and export AOT-compatible file
+    system = available_translators[system_name]["cls"](**system_params)
+    system.write_to_file(filename=args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/aotpy/translators/__init__.py
+++ b/aotpy/translators/__init__.py
@@ -4,9 +4,9 @@ objects.
 
 The aotpy objects created by these translators can be handled as any other aotpy object regardless of origin.
 """
-
 from .aof import AOFTranslator
 from .ciao import CIAOTranslator
 from .eris import ERISTranslator
 from .naomi import NAOMITranslator
 from .papyrus import PAPYRUSTranslator
+from .utils import get_available_translators

--- a/aotpy/translators/utils.py
+++ b/aotpy/translators/utils.py
@@ -1,0 +1,26 @@
+# TODO: Add module docstring
+
+from collections import namedtuple
+from . import AOFTranslator, CIAOTranslator, ERISTranslator, NAOMITranslator
+
+
+InitParameter = namedtuple("InitParameter", ["name", "type"])
+
+
+def get_available_translators() -> dict:
+    # TODO: Add docstring
+    # TODO: Define type for available_translators
+    available_translators = {"naomi": {"cls": NAOMITranslator,
+                                       "params": [InitParameter(name="path", type=str),
+                                                  InitParameter(name="at_number", type=int)]},
+                             "ciao": {"cls": CIAOTranslator,
+                                      "params": [InitParameter(name="path", type=str),
+                                                 InitParameter(name="at_number", type=int)]},
+                             "eris": {"cls": ERISTranslator,
+                                      "params": [InitParameter(name="path", type=str)]},
+                             "aof": {"cls": AOFTranslator,
+                                     "params": [InitParameter(name="path_lgs", type=str),
+                                                InitParameter(name="path_ir", type=str),
+                                                InitParameter(name="path_pix", type=str)]}
+                             }
+    return available_translators

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,7 @@ docs =
 all =
     pyvo>=1.4
     scipy>=1.5.0
+
+[options.entry_points]
+console_scripts =
+    aot-convert = aotpy.converter:main


### PR DESCRIPTION
## Description
Since most functionality for translating/parsing other telemetry formats and instantiating system objects, it is simple enough to make a CLI entry-point to allow for converting those files to an AOT archive file.

## Example
```sh
$ aot-convert

usage: AOT Converter [-h] [-o OUT] {naomi,ciao,eris,aof} ...

Convert telemetry files to AOT format.

positional arguments:
  {naomi,ciao,eris,aof}
                        available translators

options:
  -h, --help            show this help message and exit
  -o OUT, --out OUT     output file name/path
```